### PR TITLE
Convert Notion post to blog format

### DIFF
--- a/fast-growing-revenue-segments-sports-entertainment.md
+++ b/fast-growing-revenue-segments-sports-entertainment.md
@@ -1,0 +1,128 @@
+# Fast-Growing Revenue Segments in Sports and Live Entertainment
+
+The sports and live entertainment industry is experiencing unprecedented growth, driven by technological innovation, changing consumer preferences, and new engagement models. As we move through 2025, several key revenue segments are emerging as major growth drivers, reshaping how organizations monetize sports content and experiences.
+
+## The Market Landscape: A $650+ Billion Opportunity
+
+The global sports market reached nearly $484 billion in 2023 and is projected to grow to $651 billion by 2028, representing a compound annual growth rate (CAGR) of 6.1%. This growth is fueled by several converging trends that are creating new revenue opportunities across multiple segments.
+
+## 1. AI-Powered Sports Technology: The $4.7 Billion Growth Engine
+
+### Market Size and Trajectory
+The AI in sports market was valued at $1.2 billion in 2024 and is estimated to reach $4.7 billion by 2034, growing at a remarkable 14.7% CAGR. This represents one of the fastest-growing segments within the broader sports industry.
+
+### Key Revenue Drivers:
+- **Performance Analytics Software**: AI-powered tools for player movement tracking, injury prevention, and performance optimization
+- **Fan Engagement Platforms**: Automated highlight generation, personalized content delivery, and real-time analytics
+- **Smart Officiating Systems**: VAR technology, Hawk-Eye systems, and automated decision-making tools
+- **Predictive Analytics**: Injury risk assessment, game outcome predictions, and strategic planning tools
+
+### Technology Segments Leading Growth:
+- **Machine Learning** (41% market share): Driving personalized fan experiences and performance insights
+- **Computer Vision**: Real-time movement tracking and automated content creation
+- **Predictive Analytics**: Strategic planning and injury prevention
+- **Natural Language Processing**: Enhanced fan interactions and content automation
+
+## 2. Sports Management Software: The $8-10 Billion Digital Transformation
+
+### Market Overview
+The sports management software market represents an $8-10 billion opportunity, with double-digit growth expected over the next five years. This segment is being driven by increasing digitization of sports operations and the need for efficient club management.
+
+### High-Growth Subsegments:
+- **Youth League Management**: Estimated at $1 billion, serving the competitive youth sports market
+- **Performance Monitoring**: Integration of wearables and analytics platforms
+- **Fan Engagement Tools**: Mobile apps, social media management, and community building
+- **Venue Management**: Smart stadium operations and crowd analytics
+
+### Market Drivers:
+- Growing sports participation post-COVID (78,000+ amateur sports clubs in the US generating $18.7 billion in revenue)
+- Consolidation of sports clubs under franchise models
+- Rising consumer expectations for digital experiences
+- Integration of AI and machine learning capabilities
+
+## 3. Sportainment and Social Entertainment: The Experience Economy
+
+### The Rise of Competitive Socializing
+The sportainment sector combines traditional sports with hospitality, technology, and gamification, creating new revenue streams beyond traditional sports viewing.
+
+### Market Characteristics:
+- **Consumer Interest**: 60% of consumers interested in visiting sportainment concepts
+- **Market Penetration**: 30% have already visited such venues
+- **Growth Areas**: Golf entertainment venues, arcade bars, bowling restaurants, and social emporiums
+
+### Success Factors:
+1. **Location Strategy**: High-income urban areas with corporate proximity
+2. **Technology Integration**: Advanced tracking systems and gamification
+3. **Inclusive Design**: Appealing to all skill levels, not just enthusiasts
+4. **Corporate Partnerships**: Weekday revenue through corporate events and leagues
+
+## 4. Streaming and Digital Content: Personalized Fan Experiences
+
+### Revenue Growth Drivers:
+- **Streaming Payments**: 3.5% year-over-year growth in 2024 (up from 2.7% in 2023)
+- **AI-Generated Content**: Automated highlight creation and personalized feeds
+- **Interactive Broadcasting**: Enhanced viewing experiences with real-time data integration
+- **Global Accessibility**: International expansion of streaming services
+
+### Innovation Examples:
+- **Disney's ESPN AI**: Customized coverage for young, streaming-oriented viewers
+- **NBC's AI-Powered Madden Cast**: Virtual broadcasts using video game technology
+- **Real-Time Highlight Generation**: Instant content creation during live events
+
+## 5. Sports Betting and Fantasy Integration
+
+### Market Expansion:
+- Integration of betting features into mainstream sports apps
+- Fantasy sports platforms driving engagement
+- AI-powered predictions and odds calculation
+- Real-time data integration for in-game betting
+
+## 6. Health and Performance Analytics
+
+### Wearable Technology Integration:
+- **Real-time Monitoring**: Fatigue detection, injury prevention, and performance optimization
+- **Biometric Analysis**: Heart rate variability, movement patterns, and recovery metrics
+- **Personalized Training**: AI-driven workout plans and recovery protocols
+- **Long-term Health Tracking**: Career-spanning data analysis for athlete wellness
+
+## Regional Growth Opportunities
+
+### North America: Leading Innovation
+- **36% of global AI sports market share**
+- Major technology partnerships (IBM, Microsoft, Google, AWS, NVIDIA)
+- Strong integration with major leagues (NFL, NBA, MLB, NHL)
+- Advanced sports media operations
+
+### Asia-Pacific: Emerging Powerhouse
+- China's "Smart Sports Strategy" driving government investment
+- Integration of 5G and AI in smart stadiums
+- Growing international sports interest
+- Technology-first approach to fan engagement
+
+### Europe: Technology and Tradition
+- Strong football analytics adoption
+- Government support for AI development (Germany's AI Made in Germany Strategy)
+- Advanced sports broadcasting innovation
+- Privacy-conscious technology implementation
+
+## Investment Implications and Market Outlook
+
+### Key Investment Themes:
+1. **Consolidation Opportunities**: Roll-up strategies in fragmented software markets
+2. **Technology Integration**: Platforms combining multiple AI capabilities
+3. **Global Expansion**: Taking successful models to new markets
+4. **Fan Experience Innovation**: Creating new touchpoints for engagement
+
+### 2025-2026 Catalysts:
+- **Major Sporting Events**: 2026 FIFA World Cup, LA Olympics impact
+- **Technology Maturation**: AI tools becoming more accessible and affordable
+- **Demographic Shifts**: Younger, tech-savvy audiences driving demand
+- **Corporate Investment**: Increased R&D spending and strategic acquisitions
+
+## Conclusion: The Future of Sports Revenue
+
+The sports and live entertainment industry is undergoing a fundamental transformation, with technology-driven segments leading unprecedented growth. Organizations that invest in AI-powered analytics, personalized fan experiences, and innovative engagement models are positioning themselves for sustained competitive advantage.
+
+The convergence of artificial intelligence, streaming technology, and changing consumer preferences is creating new revenue opportunities that didn't exist even five years ago. As these trends accelerate, the companies that successfully integrate technology with traditional sports experiences will capture the largest share of this expanding market.
+
+The next 24 months present a unique window of opportunity, with major sporting events, technological maturation, and increased investment capital all aligning to drive growth across these key segments. Organizations that act decisively now will be best positioned to capitalize on the estimated $862 billion sports market expected by 2033.


### PR DESCRIPTION
Create a blog post `fast-growing-revenue-segments-sports-entertainment.md` by converting a Notion post about fast-growing revenue segments in sports and live entertainment.

---

[Slack Thread](https://gingerbreadcrumb.slack.com/archives/C07C3ULNZ3M/p1752166910657139?thread_ts=1752166910.657139&cid=C07C3ULNZ3M)